### PR TITLE
Issue#2 Fix handling of python requests when authentication has expired.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 udi_interface>=3.0.18
 xmltodict
-python-pushover

--- a/unifi_poly.py
+++ b/unifi_poly.py
@@ -213,7 +213,7 @@ class NetDevice(udi_interface.Node):
 if __name__ == "__main__":
     try:
         polyglot = udi_interface.Interface([])
-        polyglot.start()
+        polyglot.start('3.0.1')
         polyglot.updateProfile()
         polyglot.setCustomParamsDoc()
         Controller(polyglot, 'controller', 'controller', 'UnifiNodeServer')


### PR DESCRIPTION
The Unifi controller code was not properly handling the auth failure that occurs ~2 hrs after prior authentication.  Since the code already had some level of retries built in, it just needed to be properly triggered.  To address that:

1. Direct all responses to raise an exception on all status codes
2. Ensure the retry logic catches the HTTPError exception and triggers the retry/re-auth

I've also removed the python-pushover from the requirements.txt since it's not used AND fixed a comparison operation.

My eisy has been running with these changes in my dev environment for over a week now with no issues. 
